### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note: this is currently GTK2 only
 
 ### Arch Linux
 
-For Arch users there are two packages available in the AUR, a [Gtk2](http://aur.archlinux.org/packages/mate-applet-dock-git) version of the applet, and a [Gtk3](http://aur.archlinux.org/packages/mate-applet-dock-gtk3-git) version.
+For Arch users the GTK 3 version is available as a [package in the repositories](https://archlinux.org/packages/community/any/mate-applet-dock/).
 
 ### Gentoo based distributions
 


### PR DESCRIPTION
The links in the Arch section are broken and the information is outdated. mate-dock-applet doesn't have to be installed from the AUR anymore as there is a package in the repositories.

This PR removes the broken links and instead adds a link to the package in the official repositories.