### PR TITLE
Uses distro library as platform.linux_distributions has been removed in python 3.8

### DIFF
--- a/src/dock_xml.in
+++ b/src/dock_xml.in
@@ -42,7 +42,7 @@ files and which specifies the .desktop file to use
 import xml.etree.ElementTree as ET
 import sys
 import os
-import platform
+import distro
 
 
 def write_xml(filename, desktop_files, light_ind, show_all_apps, multi_ind,
@@ -414,9 +414,7 @@ def read_app_xml(filename):
         is running on
     """
 
-    distro, release, did = platform.linux_distribution()
-    # Note: platform.linux_distribution is deprecated. Once it is removed,
-    # the ld module can be used instead
+    distro, release, did = distro.linux_distribution()
 
     if (distro is None) or (distro == ""):
         return [False]

--- a/src/dock_xml.in
+++ b/src/dock_xml.in
@@ -42,7 +42,7 @@ files and which specifies the .desktop file to use
 import xml.etree.ElementTree as ET
 import sys
 import os
-import distro
+import distro as linux_distro
 
 
 def write_xml(filename, desktop_files, light_ind, show_all_apps, multi_ind,
@@ -414,7 +414,7 @@ def read_app_xml(filename):
         is running on
     """
 
-    distro, release, did = distro.linux_distribution()
+    distro, release, did = linux_distro.linux_distribution()
 
     if (distro is None) or (distro == ""):
         return [False]


### PR DESCRIPTION
Since python 3.8 has removed platform.linux_distribution, this PR utlizes the distro library.