### PR TITLE
Fix read_info_from_desktop_file()

### DIFF
--- a/src/dock.in
+++ b/src/dock.in
@@ -2267,7 +2267,6 @@ class Dock(object):
 
         dock_app = docked_app.DockedApp()
         dock_app.desktop_file = desktop_file
-        dock_app.read_info_from_desktop_file()
         if dock_app.read_info_from_desktop_file():
             if build_gtk2:
                 dock_app.applet_win = self.applet.window

--- a/src/docked_app.in
+++ b/src/docked_app.in
@@ -877,32 +877,36 @@ class DockedApp(object):
         """
 
         if self.desktop_file:
-            if os.path.isabs(self.desktop_file):
-                self.desktop_ai = Gio.DesktopAppInfo.new_from_filename(self.desktop_file)
-            else:
-                self.desktop_ai = Gio.DesktopAppInfo.new(self.desktop_file)
+            try:
+                if os.path.isabs(self.desktop_file):
+                    self.desktop_ai = Gio.DesktopAppInfo.new_from_filename(self.desktop_file)
+                else:
+                    self.desktop_ai = Gio.DesktopAppInfo.new(self.desktop_file)
+            except:
+                self.desktop_ai = None
 
-            self.app_name = self.desktop_ai.get_locale_string("Name")
-            self.icon_name = self.desktop_ai.get_string("Icon")
+            if self.desktop_ai is not None:
+                self.app_name = self.desktop_ai.get_locale_string("Name")
+                self.icon_name = self.desktop_ai.get_string("Icon")
 
-            # if the desktop file does not specify an icon name, use the app
-            # name instead
-            if (self.icon_name is None) or (self.icon_name == ""):
-                self.icon_name = self.app_name.lower()
+                # if the desktop file does not specify an icon name, use the app
+                # name instead
+                if (self.icon_name is None) or (self.icon_name == ""):
+                    self.icon_name = self.app_name.lower()
 
-                # hack for the MATE application browser app, where the
-                # .desktop file on Ubuntu does not specify an icon
-                if self.icon_name == "application browser":
-                    self.icon_name = "computer"
+                    # hack for the MATE application browser app, where the
+                    # .desktop file on Ubuntu does not specify an icon
+                    if self.icon_name == "application browser":
+                        self.icon_name = "computer"
 
-            # get the command specified in the .desktop file used to launch the app
-            self.cmd_line = self.desktop_ai.get_string("Exec")
+                # get the command specified in the .desktop file used to launch the app
+                self.cmd_line = self.desktop_ai.get_string("Exec")
 
-            # get the list of addtional application actions (to be activated by right
-            # clicking the app's dock icon)
-            self.rc_actions = self.desktop_ai.list_actions()
+                # get the list of addtional application actions (to be activated by right
+                # clicking the app's dock icon)
+                self.rc_actions = self.desktop_ai.list_actions()
 
-            return True
+                return True
 
         return False
 


### PR DESCRIPTION
`Gio.DesktopAppInfo.new()` and `Gio.DesktopAppInfo.new_from_filename()` may return `NULL` which would cause a `TypeError` exception and in turn crash the dock applet like that:
```
Traceback (most recent call last):
  File "/usr/lib/mate-applets/mate-dock-applet/dock.py", line 2432, in setup_app_list
    if dock_app.read_info_from_desktop_file():
  File "/usr/lib/mate-applets/mate-dock-applet/docked_app.py", line 881, in read_info_from_desktop_file
    self.desktop_ai = Gio.DesktopAppInfo.new_from_filename(self.desktop_file)
TypeError: constructor returned NULL
```
Thus, it is necessary to catch this exception so that `read_info_from_desktop_file()` can gracefully return `False`.